### PR TITLE
fixed: order activities by id instead of timestamp:

### DIFF
--- a/app/db/activity_store.py
+++ b/app/db/activity_store.py
@@ -58,7 +58,7 @@ def get_all_activities(order="DESC"):
     try:
         cursor = config.db_connection.cursor()
         cursor.execute(
-            f"SELECT type, txhash, command, result, context, timestamp FROM activities ORDER by timestamp {order}"
+            f"SELECT type, txhash, command, result, context, timestamp FROM activities ORDER by id {order}"
         )
         result = cursor.fetchall()
         return result  # Returns a list of tuples where each tuple is (type, txhash, command, result, context )

--- a/app/db/activity_store.py
+++ b/app/db/activity_store.py
@@ -57,9 +57,7 @@ def insert_tx_activity_by_response(response: requests.Response, context):
 def get_all_activities(order="DESC"):
     try:
         cursor = config.db_connection.cursor()
-        cursor.execute(
-            f"SELECT type, txhash, command, result, context, timestamp FROM activities ORDER by id {order}"
-        )
+        cursor.execute(f"SELECT type, txhash, command, result, context, timestamp FROM activities ORDER by id {order}")
         result = cursor.fetchall()
         return result  # Returns a list of tuples where each tuple is (type, txhash, command, result, context )
     except Error as e:


### PR DESCRIPTION
 multiple activities with the same timestamp were shown in the wrong order