### PR TITLE
cron jobs for EA: upgrade & reconnect

### DIFF
--- a/internet_check_restart.sh
+++ b/internet_check_restart.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Function to log messages
+log_message() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+}
+
+# Function to check internet connection
+check_internet() {
+    ping -c 1 8.8.8.8 > /dev/null 2>&1
+    return $?
+}
+
+# Check internet connection
+if check_internet; then
+    log_message "Internet connection is available."
+else
+    log_message "No internet connection. Restarting the device..."
+    sudo reboot
+fi

--- a/prepare_energy_agent.sh
+++ b/prepare_energy_agent.sh
@@ -31,3 +31,17 @@ rm ../get-docker.sh
 echo "Docker and Docker Compose setup complete. The services are now running."
 
 EOF
+
+echo "Establishing cron jobs for automated ugprades and reconnectivity."
+
+#  Install cronjob to look for updates in randomly once between 0-25 min randomly selected
+CRONJOB_UPGRADE = "*/30 * * * *   cd ~/energy-agent && sleep \$(( $RANDOM % 1500 )) && docker system prune -f && docker compose up -d"
+(crontab -l 2>/dev/null; echo "$CRONJOB_UPGRADE") | crontab -
+
+
+wget https://github.com/rddl-network/EnergyAgent/raw/main/internet_check_restart.sh
+sudo mv internet_check_restart.sh /usr/local/bin/
+sudo chmod +x /usr/local/bin/internet_check_restart.sh
+
+CRONJOB_RECONNECT = "*/15 * * * * /usr/bin/systemd-cat -t internet-check /usr/bin/sudo /usr/local/bin/internet_check_restart.sh"
+(crontab -l 2>/dev/null; echo "$CRONJOB_RECONNECT") | crontab -


### PR DESCRIPTION
set up cron jobs for EA:
* automated upgrade with a bit of client based balancing
* connectivity check and reboot